### PR TITLE
gh-2: uses jsonb instead of a string to hold the board information.

### DIFF
--- a/code/tic-tac-tow-service/build.gradle.kts
+++ b/code/tic-tac-tow-service/build.gradle.kts
@@ -28,8 +28,9 @@ dependencies {
 	implementation("org.springframework.security:spring-security-core:5.7.3")
 
 	// for JDBI
-	implementation("org.jdbi:jdbi3-core:3.32.0")
-	implementation("org.jdbi:jdbi3-kotlin:3.32.0")
+	implementation("org.jdbi:jdbi3-core:3.33.0")
+	implementation("org.jdbi:jdbi3-kotlin:3.33.0")
+    implementation("org.jdbi:jdbi3-postgres:3.33.0")
 	implementation("org.postgresql:postgresql:42.5.0")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/code/tic-tac-tow-service/sql/create-schema.sql
+++ b/code/tic-tac-tow-service/sql/create-schema.sql
@@ -14,7 +14,7 @@ create table dbo.Tokens(
 create table dbo.Games(
     id UUID not null,
     state VARCHAR(64) not null,
-    board CHAR(9) not null,
+    board jsonb not null,
     created int not null,
     updated int not null,
     deadline int,

--- a/code/tic-tac-tow-service/src/main/kotlin/pt/isel/daw/tictactow/domain/Board.kt
+++ b/code/tic-tac-tow-service/src/main/kotlin/pt/isel/daw/tictactow/domain/Board.kt
@@ -1,7 +1,7 @@
 package pt.isel.daw.tictactow.domain
 
 data class Board(
-    private val cells: Array<Array<State>>
+    val cells: Array<Array<State>>
 ) {
     init {
         require(

--- a/code/tic-tac-tow-service/src/main/kotlin/pt/isel/daw/tictactow/repository/jdbi/Utils.kt
+++ b/code/tic-tac-tow-service/src/main/kotlin/pt/isel/daw/tictactow/repository/jdbi/Utils.kt
@@ -2,6 +2,7 @@ package pt.isel.daw.tictactow.repository.jdbi
 
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.KotlinPlugin
+import org.jdbi.v3.postgres.PostgresPlugin
 import pt.isel.daw.tictactow.repository.jdbi.mappers.BoardMapper
 import pt.isel.daw.tictactow.repository.jdbi.mappers.InstantMapper
 import pt.isel.daw.tictactow.repository.jdbi.mappers.PasswordValidationInfoMapper
@@ -9,6 +10,7 @@ import pt.isel.daw.tictactow.repository.jdbi.mappers.TokenValidationInfoMapper
 
 fun Jdbi.configure(): Jdbi {
     installPlugin(KotlinPlugin())
+    installPlugin(PostgresPlugin())
 
     registerColumnMapper(PasswordValidationInfoMapper())
     registerColumnMapper(TokenValidationInfoMapper())

--- a/code/tic-tac-tow-service/src/main/kotlin/pt/isel/daw/tictactow/repository/jdbi/mappers/BoardMapper.kt
+++ b/code/tic-tac-tow-service/src/main/kotlin/pt/isel/daw/tictactow/repository/jdbi/mappers/BoardMapper.kt
@@ -2,13 +2,16 @@ package pt.isel.daw.tictactow.repository.jdbi.mappers
 
 import org.jdbi.v3.core.mapper.ColumnMapper
 import org.jdbi.v3.core.statement.StatementContext
+import org.postgresql.util.PGobject
 import pt.isel.daw.tictactow.domain.Board
+import pt.isel.daw.tictactow.repository.jdbi.JdbiGamesRepository
 import java.sql.ResultSet
 import java.sql.SQLException
 
 class BoardMapper : ColumnMapper<Board> {
     @Throws(SQLException::class)
     override fun map(r: ResultSet, columnNumber: Int, ctx: StatementContext?): Board {
-        return Board.fromString(r.getString(columnNumber))
+        val obj = r.getObject(columnNumber, PGobject::class.java)
+        return JdbiGamesRepository.deserializeBoardFromJson(obj.value ?: throw IllegalArgumentException("TODO"))
     }
 }

--- a/code/tic-tac-tow-service/src/test/kotlin/pt/isel/daw/tictactow/repository/GameRepositoryTests.kt
+++ b/code/tic-tac-tow-service/src/test/kotlin/pt/isel/daw/tictactow/repository/GameRepositoryTests.kt
@@ -4,8 +4,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import pt.isel.daw.tictactow.RealClock
+import pt.isel.daw.tictactow.domain.Board
 import pt.isel.daw.tictactow.domain.GameLogic
 import pt.isel.daw.tictactow.domain.PasswordValidationInfo
+import pt.isel.daw.tictactow.domain.Position
 import pt.isel.daw.tictactow.repository.jdbi.JdbiGamesRepository
 import pt.isel.daw.tictactow.repository.jdbi.JdbiUsersRepository
 import pt.isel.daw.tictactow.utils.testWithHandleAndRollback
@@ -36,5 +38,17 @@ class GameRepositoryTests {
 
         // then: the two games are equal
         assertEquals(game, retrievedGame)
+
+        // when: updating the game
+        val newGame = game.copy(board = game.board.mutate(Position(1, 1), Board.State.PLAYER_X))
+
+        // and: storing the game
+        gameRepo.update(newGame)
+
+        // and: retrieving the game again
+        val newRetrievedGame = gameRepo.getById(game.id)
+
+        // then: the two games are equal
+        assertEquals(newGame, newRetrievedGame)
     }
 }


### PR DESCRIPTION
This PR exemplifies the use of the `jsonb` PostgreSQL type to hold structured information in a single column.